### PR TITLE
fix: align supported node versions with jest (#14)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=16"
+    "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
   },
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
## Description

Support same versions of node as Jest:  https://github.com/facebook/jest/blob/v28.1.1/package.json#L168