### PR TITLE
fix: add additional peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "test": "jest"
   },
   "peerDependencies": {
-    "jest": "^28"
+    "jest": "^28",
+    "jest-runtime": "^28",
+    "@jest/transform": "^28"
   },
   "devDependencies": {
     "@commitlint/cli": "17.0.2",


### PR DESCRIPTION
## Description

Add additional peer deps to prevent warnings during install

Fixes:  https://github.com/reside-eng/jest-runtime/issues/17